### PR TITLE
Replace slow `not qs` operation.

### DIFF
--- a/next_prev.py
+++ b/next_prev.py
@@ -24,7 +24,7 @@ def next_or_prev_in_order(instance, qs=None, prev=False, loop=False):
        queryset ordering. If loop is True, return the first/last item when the
        end/start is reached. """
 
-    if not qs:
+    if qs is None:
         qs = instance.__class__.objects.all()
 
     if prev:


### PR DESCRIPTION
`not qs` can be very slow for large querysets.

I tested calling `prev_in_order(sample, qs=Sample.objects.all())` with 16000 Samples and it took 200-500ms while the rest of `next_or_prev_in_order` function took less than 10ms. (Django==3.0.6; django-next-prev==1.0.1)